### PR TITLE
add function to generate calibrations in realtime pipeline

### DIFF
--- a/ovrolwasolar/calibration.py
+++ b/ovrolwasolar/calibration.py
@@ -136,13 +136,17 @@ def make_fast_caltb_from_slow(calib_ms, solar_ms, caltb, \
     msmd.done()
     return caltb_fast
     
-def gen_calibration(msfile, modelcl=None, uvrange='', bcaltb=None, logging_level='info', caltable_fold='caltables',refant='202'):
+def gen_calibration(msfile, modelcl=None, uvrange='>10lambda', bcaltb=None, logging_level='info', caltable_fold='caltables', 
+        refant='202'):
     """
     This function is for doing initial self-calibrations using strong sources that are above the horizon
-    It is recommended to use a dataset observed at night when the Sun is not in the field of view
+    It is recommended to use a dataset observed at night when the Sun is not in the field of view with the same attenuator settings
     :param uvrange: uv range to consider for calibration. Following CASA's syntax, e.g., '>1lambda'
     :param msfile: input CASA ms visibility for calibration
     :param modelcl: input model of strong sources as a component list, produced from gen_model_cl()
+    :param bcaltb: name of the output bandpass calibration table
+    :param caltable_fold: directory to store the bandpass calibration table
+    :param refant: reference antenna to be used
     """
 	
     time1=timeit.default_timer()
@@ -164,6 +168,7 @@ def gen_calibration(msfile, modelcl=None, uvrange='', bcaltb=None, logging_level
 
     if not bcaltb:
         bcaltb = caltable_fold + "/" + os.path.basename(msfile).replace('.ms', '.bcal')
+
 
     logging.info("Generating bandpass solution")
     bandpass(msfile, caltable=bcaltb, uvrange=uvrange, combine='scan,field,obs', fillgaps=0,refant=refant)


### PR DESCRIPTION
Two new functions added in solar_realtime_pipeline.py.
- download_calibms() is to download all calibration files using an input time. Also do auto-correlation-based flagging (default to True). This can be used to assess the quality of the calibration file. 
- gen_caltables() is to take the downloaded and flagged ms and do bandpass calibration. Also perform flagging of all outrigger antennas to prepare for beamforming calibration tables.

Example usage:
`import solar_realtime_pipeline as realtime`
`ms_calib = realtime.download_calibms('2024-02-10T14:05:30')`
`bcaltbs, bcaltbs_bm = realtime.gen_caltables(ms_calib)`

Default working directory is /lustre/bin.chen/realtime_pipeline/ms_calib/, and output calibration tables are in /lustre/bin.chen/realtime_pipeline/caltables/. One can change them using keywords "download_fold" and "caltable_fold," respectively.