### PR TITLE
add time_end option in realtime pipeline

### DIFF
--- a/ovrolwasolar/flagging.py
+++ b/ovrolwasolar/flagging.py
@@ -362,6 +362,8 @@ def perform_baseline_flagging(msfile,verbose=False,n_clusters = 128):
     :param n_clusters: number of clusters to use for KMeans clustering
     """
 
+    from sklearn.cluster import KMeans
+
 
     tb = table()
     msmd = msmetadata()


### PR DESCRIPTION
Two changes:

1. Add "time_end" option in realtime pipeline. If provided, the pipeline will end at the specified time

2. Move the import of KMeans in ovrolwasolar/flagging.py to under the func_baseline_flagging() function. Once the baseline flagging method is fully tested and incorporated, "sklearn" can be included as a required package.  

@peijin94 